### PR TITLE
Changing binaries and refactoring code

### DIFF
--- a/project_URIPlugin.cpp.in
+++ b/project_URIPlugin.cpp.in
@@ -6,8 +6,14 @@
 #  define Q_GHS_KEEP_REFERENCE(S)
 #endif
 
+#ifdef QT_STATICPLUGIN
+extern void qml_static_register_types_@__qml_plugin_uri_name_for_class@();
+Q_GHS_KEEP_REFERENCE(qml_static_register_types_@__qml_plugin_uri_name_for_class@)
+#else
 extern void qml_register_types_@__qml_plugin_uri_name_for_class@();
 Q_GHS_KEEP_REFERENCE(qml_register_types_@__qml_plugin_uri_name_for_class@)
+#endif
+
 @__qml_plugin_static_register_content@
 class @__qml_plugin_uri_name_for_class@Plugin : public QQmlEngineExtensionPlugin
 {


### PR DESCRIPTION
Not testing on macos, only linux

Hi, I came across your repository and decided to try using it in my project, but I encountered a few issues. I decided to solve them and contribute back with my fixes.

1. I added binary lookup using the same `qmake` that is used for building. In theory, if Qt is available, `qmake` should be available too (although it might be better to improve this in case `qmake` is not found in `$PATH`).
2. When I created a module with the name "org.example.core" for a QML file, the dots in the module name were not removed when generating class names, so the class names still contained dots. To fix this, I added a separate variable that stores the module name in lowercase without dots.
3. Also, in the generated CPP file, there was a missing `extern` check for static modules, so I added it.
